### PR TITLE
Add 'auto' option for radius_bound

### DIFF
--- a/environments/chaotic_pendulum.py
+++ b/environments/chaotic_pendulum.py
@@ -62,7 +62,7 @@ class ChaoticPendulum(Environment):
         """Returns:
             radius_bounds (tuple): (min, max) radius bounds for the environment.
         """
-        return (1.3, 2.3)
+        return (0.5, 1.3)
 
     def _dynamics(self, t, states):
         """Defines system dynamics

--- a/environments/chaotic_pendulum.py
+++ b/environments/chaotic_pendulum.py
@@ -60,7 +60,7 @@ class ChaoticPendulum(Environment):
 
     def get_default_radius_bounds(self):
         """Returns:
-        radius_bounds (tuple): (min, max) radius bounds for the environment.
+            radius_bounds (tuple): (min, max) radius bounds for the environment.
         """
         return (1.3, 2.3)
 

--- a/environments/chaotic_pendulum.py
+++ b/environments/chaotic_pendulum.py
@@ -58,6 +58,12 @@ class ChaoticPendulum(Environment):
         """Return maximum noise std that keeps the environment stable."""
         return 0.05
 
+    def get_default_radius_bounds(self):
+        """Returns:
+        radius_bounds (tuple): (min, max) radius bounds for the environment.
+        """
+        return (1.3, 2.3)
+
     def _dynamics(self, t, states):
         """Defines system dynamics
 

--- a/environments/datasets.py
+++ b/environments/datasets.py
@@ -42,7 +42,9 @@ class EnvironmentSampler(Dataset):
                 trajectory.
             radius_bound (float, float): Radius lower and upper bound of the phase state sampling.
                 Init phase states will be sampled from a circle (q, p) of radius
-                r ~ U(radius_bound[0], radius_bound[1]) https://arxiv.org/pdf/1909.13789.pdf (Sec. 4)
+                r ~ U(radius_bound[0], radius_bound[1]) https://arxiv.org/pdf/1909.13789.pdf (Sec 4)
+                Optionally, it can be a string 'auto'. In that case, the value returned by
+                environment.get_default_radius_bounds() will be returned.
             seed (int): Seed for reproducibility.
             dtype (torch.type): Type of the sampled tensors.
         """

--- a/environments/environment.py
+++ b/environments/environment.py
@@ -81,6 +81,8 @@ class Environment(ABC):
 
         Args:
             radius_bound (float, float): Radius lower and upper bound of the phase state sampling.
+                Optionally, it can be a string 'auto'. In that case, the value returned by
+                get_default_radius_bounds() will be returned.
 
         Raises:
             NotImplementedError: Class instantiation has no implementation
@@ -133,6 +135,8 @@ class Environment(ABC):
             radius_bound (float, float): Radius lower and upper bound of the phase state sampling.
                 Init phase states will be sampled from a circle (q, p) of radius
                 r ~ U(radius_bound[0], radius_bound[1]) https://arxiv.org/pdf/1909.13789.pdf (Sec. 4)
+                Optionally, it can be a string 'auto'. In that case, the value returned by
+                get_default_radius_bounds() will be returned.
             seed (int): Seed for reproducibility.
         Raises:
             AssertError: If radius_bound[0] > radius_bound[1]

--- a/environments/environment.py
+++ b/environments/environment.py
@@ -70,6 +70,12 @@ class Environment(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def get_default_radius_bounds(self):
+        """Returns a tuple (min, max) with the default radius bounds for the environment.
+        """
+        raise NotImplementedError
+
     def _sample_init_conditions(self, radius_bound):
         """Samples random initial conditions for the environment
 
@@ -134,6 +140,8 @@ class Environment(ABC):
             (ndarray): Array of shape (Batch, Nframes, Height, Width, Channels).
                 Contains sampled rollouts
         """
+        if radius_bound == 'auto':
+            radius_bound = self.get_default_radius_bounds()
         radius_lb, radius_ub = radius_bound
         assert radius_lb <= radius_ub
         if seed is not None:

--- a/environments/gravity.py
+++ b/environments/gravity.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 from environment import Environment, visualize_rollout
@@ -81,7 +83,8 @@ class NObjectGravity(Environment):
         elif self.n_objects == 3:
             return (0.9, 1.2)
         else:
-            return (1., 1.)  # TODO: Should we raise an error?
+            warnings.warn('Gravity for n > 3 objects can have undefined behavior.')
+            return (0.3, 0.5)
 
     def _dynamics(self, t, states):
         """Defines system dynamics

--- a/environments/gravity.py
+++ b/environments/gravity.py
@@ -72,6 +72,17 @@ class NObjectGravity(Environment):
         else:
             return 0.
 
+    def get_default_radius_bounds(self):
+        """Returns:
+        radius_bounds (tuple): (min, max) radius bounds for the environment.
+        """
+        if self.n_objects == 2:
+            return (0.5, 1.5)
+        elif self.n_objects == 3:
+            return (0.9, 1.2)
+        else:
+            return (1., 1.)  # TODO: Should we raise an error?
+
     def _dynamics(self, t, states):
         """Defines system dynamics
 

--- a/environments/gravity.py
+++ b/environments/gravity.py
@@ -74,7 +74,7 @@ class NObjectGravity(Environment):
 
     def get_default_radius_bounds(self):
         """Returns:
-        radius_bounds (tuple): (min, max) radius bounds for the environment.
+            radius_bounds (tuple): (min, max) radius bounds for the environment.
         """
         if self.n_objects == 2:
             return (0.5, 1.5)
@@ -190,6 +190,8 @@ class NObjectGravity(Environment):
         """Samples random initial conditions for the environment
         Args:
             radius_bound (float, float): Radius lower and upper bound of the phase state sampling.
+                Optionally, it can be a string 'auto'. In that case, the value returned by
+                get_default_radius_bounds() will be returned.
         """
         radius_lb, radius_ub = radius_bound
         radius = np.random.rand()*(radius_ub - radius_lb) + radius_lb

--- a/environments/pendulum.py
+++ b/environments/pendulum.py
@@ -57,6 +57,12 @@ class Pendulum(Environment):
         """Return maximum noise std that keeps the environment stable."""
         return 0.1
 
+    def get_default_radius_bounds(self):
+        """Returns:
+        radius_bounds (tuple): (min, max) radius bounds for the environment.
+        """
+        return (1.3, 2.3)
+
     def _dynamics(self, t, states):
         """Defines system dynamics
 

--- a/environments/pendulum.py
+++ b/environments/pendulum.py
@@ -59,7 +59,7 @@ class Pendulum(Environment):
 
     def get_default_radius_bounds(self):
         """Returns:
-        radius_bounds (tuple): (min, max) radius bounds for the environment.
+            radius_bounds (tuple): (min, max) radius bounds for the environment.
         """
         return (1.3, 2.3)
 
@@ -116,6 +116,8 @@ class Pendulum(Environment):
 
         Args:
             radius_bound (float, float): Radius lower and upper bound of the phase state sampling.
+                Optionally, it can be a string 'auto'. In that case, the value returned by
+                get_default_radius_bounds() will be returned.
         """
         radius_lb, radius_ub = radius_bound
         radius = np.random.rand()*(radius_ub - radius_lb) + radius_lb

--- a/environments/spring.py
+++ b/environments/spring.py
@@ -56,7 +56,7 @@ class Spring(Environment):
 
     def get_default_radius_bounds(self):
         """Returns:
-        radius_bounds (tuple): (min, max) radius bounds for the environment.
+            radius_bounds (tuple): (min, max) radius bounds for the environment.
         """
         return (0.1, 1.0)
 
@@ -109,6 +109,8 @@ class Spring(Environment):
 
         Args:
             radius_bound (float, float): Radius lower and upper bound of the phase state sampling.
+                Optionally, it can be a string 'auto'. In that case, the value returned by
+                get_default_radius_bounds() will be returned.
         """
         radius_lb, radius_ub = radius_bound
         radius = np.random.rand()*(radius_ub - radius_lb) + radius_lb

--- a/environments/spring.py
+++ b/environments/spring.py
@@ -54,6 +54,12 @@ class Spring(Environment):
         """Return maximum noise std that keeps the environment stable."""
         return 0.1
 
+    def get_default_radius_bounds(self):
+        """Returns:
+        radius_bounds (tuple): (min, max) radius bounds for the environment.
+        """
+        return (0.1, 1.0)
+
     def _dynamics(self, t, states):
         """Defines system dynamics
 

--- a/experiment_params/default_online.yaml
+++ b/experiment_params/default_online.yaml
@@ -4,12 +4,9 @@ model_save_dir: "saved_models"
 
 gpu_id: 0  # Will use this gpu if available
 
-# Define environment
-environment:
+environment:  # Parameters must correspond to arguments
+              # of the environment __init__()
   name: "Pendulum"
-
-  # The following parameters must correspond in name and type
-  # to the environment __init__() arguments
   mass: 0.5
   length: 1
   g: 3
@@ -17,9 +14,10 @@ environment:
 # Define data characteristics
 dataset:
   img_size: 32
-  radius_bound: [1.3, 2.3]
   num_train_samples: 50000  # Total number of rollouts used when training on-line.
   num_test_samples: 100  # Number of test samples.
+  radius_bound: 'auto'  # A tuple (min, max) or 'auto', in which case
+                        # the environment default bounds will be used
   rollout:
     seq_length: 30
     delta_time: 0.125


### PR DESCRIPTION
The `Environment.sample_random_rollouts()` now accepts `radius_bound='auto'`, that makes it use the default `radius_bound` as returned by each environment new method `get_default_radius_bound()`.

The `Environment` class now defines an abstract `get_default_radius_bound()` method that all environments must implement.