### PR TITLE
HGN working without transformer

### DIFF
--- a/experiment_params/train_config_no_transformer.yaml
+++ b/experiment_params/train_config_no_transformer.yaml
@@ -1,0 +1,45 @@
+experiment_id: "default_offline"
+model_save_dir: "saved_models"
+
+device: 'cuda:0'  # Will use this device if available, otherwise wil use cpu
+
+# Define networks architectures
+networks:
+  variational: True
+  dtype : "float"
+  encoder:
+    hidden_conv_layers: 6
+    n_filters: [32, 64, 64, 64, 64, 64, 64]  # first + hidden
+    kernel_sizes: [3, 3, 3, 3, 3, 3, 3, 3]  # first + hidden + last
+    strides: [1, 1, 1, 1, 1, 2, 2, 2]  # first + hidden + last
+    out_channels: 32
+  transformer:
+    hidden_conv_layers: 1
+    n_filters: [64, 64]  # first + hidden
+    kernel_sizes: [3, 3, 3]  # first + hidden + last
+    strides: [2, 2, 2]  # first + hidden + last
+    out_channels: 16  # Channels of q, and p splitted
+  hamiltonian:
+    hidden_conv_layers: 4
+    in_shape: [16, 4, 4]  # Should be coherent with transformer output
+    n_filters: [32, 64, 64, 64, 64, 64]  # first + hidden
+    kernel_sizes: [3, 3, 3, 3, 3, 3]  # first + hidden + last
+    strides: [1, 1, 1, 1, 1, 1]  # first + hidden + last
+  decoder:
+    n_residual_blocks: 3
+    n_filters: [64, 64, 64]
+    kernel_sizes: [3, 3, 3, 3]
+
+# Define HGN Integrator
+integrator:
+  method: "Leapfrog"
+
+# Define optimization
+optimization:
+  epochs: 5
+  batch_size: 16
+  # Learning rates
+  encoder_lr: 1.5e-4
+  transformer_lr: 1.5e-4
+  hnn_lr: 1.5e-4
+  decoder_lr: 1.5e-4

--- a/experiment_params/train_config_no_transformer.yaml
+++ b/experiment_params/train_config_no_transformer.yaml
@@ -12,19 +12,14 @@ networks:
     n_filters: [32, 64, 64, 64, 64, 64, 64]  # first + hidden
     kernel_sizes: [3, 3, 3, 3, 3, 3, 3, 3]  # first + hidden + last
     strides: [1, 1, 1, 1, 1, 2, 2, 2]  # first + hidden + last
-    out_channels: 32
-  transformer:
-    hidden_conv_layers: 1
-    n_filters: [64, 64]  # first + hidden
-    kernel_sizes: [3, 3, 3]  # first + hidden + last
-    strides: [2, 2, 2]  # first + hidden + last
-    out_channels: 16  # Channels of q, and p splitted
+    out_channels: 48
   hamiltonian:
-    hidden_conv_layers: 4
-    in_shape: [16, 4, 4]  # Should be coherent with transformer output
-    n_filters: [32, 64, 64, 64, 64, 64]  # first + hidden
-    kernel_sizes: [3, 3, 3, 3, 3, 3]  # first + hidden + last
-    strides: [1, 1, 1, 1, 1, 1]  # first + hidden + last
+    hidden_conv_layers: 3
+    in_shape: [ 16, 4, 4 ]  # Should be coherent with transformer output
+    n_filters: [ 32, 64, 64, 64 ]  # first + hidden
+    kernel_sizes: [ 3, 2, 2, 2, 2 ]  # first + hidden + last
+    strides: [ 1, 2, 1, 1, 1 ]  # first + hidden + last
+    paddings: [ 1, 0, [ 0, 1, 0, 1 ], [ 0, 1, 0, 1 ], 0 ]  # first + hidden + last
   decoder:
     n_residual_blocks: 3
     n_filters: [64, 64, 64]
@@ -38,8 +33,21 @@ integrator:
 optimization:
   epochs: 5
   batch_size: 16
+  input_frames: 5  # Number of frames to feed to the encoder while training
   # Learning rates
   encoder_lr: 1.5e-4
   transformer_lr: 1.5e-4
   hnn_lr: 1.5e-4
   decoder_lr: 1.5e-4
+
+geco:
+  alpha: 0.99 # decay of the moving average
+  tol: 3.3e-2 # per pixel error tolerance. keep in mind this gets squared
+  initial_lagrange_multiplier: 1.0 # this is 1/beta
+  lagrange_multiplier_param: 0.1   # adjust update on langrange multiplier
+  # To train in a beta-vae fashion use the following parameters:
+  # alpha: 0.0
+  # tol: 0.0
+  # initial_lagrange_multiplier: 1 / beta
+  # lagrange_multiplier_param = 1.0
+

--- a/experiment_params/train_config_no_transformer.yaml
+++ b/experiment_params/train_config_no_transformer.yaml
@@ -12,7 +12,7 @@ networks:
     n_filters: [32, 64, 64, 64, 64, 64, 64]  # first + hidden
     kernel_sizes: [3, 3, 3, 3, 3, 3, 3, 3]  # first + hidden + last
     strides: [1, 1, 1, 1, 1, 2, 2, 2]  # first + hidden + last
-    out_channels: 48
+    out_channels: 32
   hamiltonian:
     hidden_conv_layers: 3
     in_shape: [ 16, 4, 4 ]  # Should be coherent with transformer output

--- a/hamiltonian_generative_network.py
+++ b/hamiltonian_generative_network.py
@@ -10,7 +10,7 @@ from utilities.hgn_result import HgnResult
 
 class HGN:
     """Hamiltonian Generative Network model.
-    
+
     This class models the HGN and implements its training and evaluation.
     """
     ENCODER_FILENAME = "encoder.pt"
@@ -93,7 +93,8 @@ class HGN:
         prediction.set_z(z_sample=z, z_mean=z_mean, z_logvar=z_logvar)
 
         # Initial state
-        q, p = self.transformer(z)
+        #q, p = self.transformer(z)
+        q, p = torch.split(z, z.size(1)//2, dim=1)
         prediction.append_state(q=q, p=p)
 
         # Initial state reconstruction
@@ -105,15 +106,17 @@ class HGN:
             # Compute next state
             q, p = self.integrator.step(q=q, p=p, hnn=self.hnn)
             prediction.append_state(q=q, p=p)
-            prediction.append_energy(self.integrator.energy)  # This is the energy of previous timestep
+            # This is the energy of previous timestep
+            prediction.append_energy(self.integrator.energy)
 
             # Compute state reconstruction
             x_reconstructed = self.decoder(q)
             prediction.append_reconstruction(x_reconstructed)
-        
+
         # We need to add the energy of the system at the last time-step
         last_energy = self.hnn(q=q, p=p).detach().cpu().numpy()
-        prediction.append_energy(last_energy)  # This is the energy of previous timestep
+        # This is the energy of previous timestep
+        prediction.append_energy(last_energy)
         return prediction
 
     def fit(self, rollouts, variational=True):

--- a/train.py
+++ b/train.py
@@ -89,10 +89,6 @@ class HgnTrainer:
                 'lr': params["optimization"]["encoder_lr"]
             },
             {
-                'params': self.hgn.transformer.parameters(),
-                'lr': params["optimization"]["transformer_lr"]
-            },
-            {
                 'params': self.hgn.hnn.parameters(),
                 'lr': params["optimization"]["hnn_lr"]
             },
@@ -101,6 +97,11 @@ class HgnTrainer:
                 'lr': params["optimization"]["decoder_lr"]
             },
         ]
+        if self.hgn.transformer is not None:
+            optim_params.append(
+                {'params': self.hgn.transformer.parameters(),
+                 'lr': params["optimization"]["transformer_lr"]},
+            )
         self.optimizer = torch.optim.Adam(optim_params)
 
     def load_and_reset(self, params, device, dtype):

--- a/utilities/loader.py
+++ b/utilities/loader.py
@@ -24,11 +24,14 @@ def instantiate_encoder(params, device, dtype):
 
 
 def instantiate_transformer(params, device, dtype):
-    transformer = TransformerNet(
-        in_channels=params["networks"]["encoder"]["out_channels"],
-        **params["networks"]["transformer"],
-        dtype=dtype).to(device)
-    return transformer
+    if "transformer" in params["networks"]:
+        transformer = TransformerNet(
+            in_channels=params["networks"]["encoder"]["out_channels"],
+            **params["networks"]["transformer"],
+            dtype=dtype).to(device)
+        return transformer
+    else:
+        return None
 
 
 def instantiate_hamiltonian(params, device, dtype):
@@ -59,14 +62,19 @@ def load_hgn(params, device, dtype):
                          in_channels=params["dataset"]["rollout"]["n_channels"],
                          **params["networks"]["encoder"],
                          dtype=dtype).to(device)
-    transformer = TransformerNet(
-        in_channels=params["networks"]["encoder"]["out_channels"],
-        **params["networks"]["transformer"],
-        dtype=dtype).to(device)
+    if "transformer" in params["networks"]:
+        transformer = TransformerNet(
+            in_channels=params["networks"]["encoder"]["out_channels"],
+            **params["networks"]["transformer"],
+            dtype=dtype).to(device)
+        decoder_in_channels = params["networks"]["transformer"]["out_channels"]
+    else:
+        transformer = None
+        decoder_in_channels = params["networks"]["encoder"]["out_channels"] / 2
     hnn = HamiltonianNet(**params["networks"]["hamiltonian"],
                          dtype=dtype).to(device)
     decoder = DecoderNet(
-        in_channels=params["networks"]["transformer"]["out_channels"],
+        in_channels=decoder_in_channels,
         out_channels=params["dataset"]["rollout"]["n_channels"],
         **params["networks"]["decoder"],
         dtype=dtype).to(device)


### PR DESCRIPTION
This pull request makes HGN work without the transformer. If `transformer` is not present under `networks` in the configuration, HGN will not use it. The latent encoding will be split into `q` and `p` and used. Therefore, the encoder and hamiltonian networks should handle dimensions appropriately.

I updated the `train_config_no_transformer.yaml` by making the latent encoding of 32 channels instead of 48, so that q and p are of 16 channels each.