### PR TITLE
modifies q_next update in leapfrog integrator

### DIFF
--- a/utilities/integrator.py
+++ b/utilities/integrator.py
@@ -128,7 +128,8 @@ class Integrator:
         _, dp_dt = self._get_grads(q, p, hnn, remember_energy=True)
         # leapfrog step
         p_next_half = p + dp_dt * (self.delta_t) / 2
-        q_next = q + p_next_half * self.delta_t
+        dq_dt, _ = self._get_grads(q, p_next_half, hnn)
+        q_next = q + dq_dt * self.delta_t
         # momentum synchronization
         _, dp_next_dt = self._get_grads(q_next, p_next_half, hnn)
         p_next = p_next_half + dp_next_dt * (self.delta_t) / 2


### PR DESCRIPTION
https://github.com/CampusAI/Hamiltonian-Generative-Networks/blob/702d3ff3aec40eba20e17c5a1612b5b0b1e2f831/utilities/integrator.py#L131

I think there is an issue with the leapfrog step. The current implementation updates q using:
```
p_next_half = p + dp_dt * (self.delta_t) / 2
q_next = q + p_next_half * self.delta_t
```

I think it should be changed to:
```
p_next_half = p + dp_dt * (self.delta_t) / 2
dq_dt, _ = self._get_grads(q, p_next_half, hnn)
q_next = q + dq_dt * self.delta_t
```